### PR TITLE
feat: implement basic interface for local variables & numeric operations

### DIFF
--- a/examples/hello.xml
+++ b/examples/hello.xml
@@ -1,7 +1,7 @@
 <Root module="tobster">
     <Func name="ZdraveitePriqteliAzSumTobstera">
         <Print format="%s\n">
-            <String>Hello, world!</String>
+            <Value type="String">Hello, world!</Value>
         </Print>
     </Func>
 </Root>

--- a/examples/var.xml
+++ b/examples/var.xml
@@ -1,0 +1,23 @@
+<Root module="variables">
+    <Func name="ZdraveitePriqteliAzSumTobstera">
+        <Var name="x" type="Int32"/>
+        <Store name="x">
+            <Value type="Int32">35</Value>
+        </Store>
+        <Var name="y">
+            <Value type="Int32">35</Value>
+        </Var>
+        <Var name="z">
+            <Value type="Int32">1</Value>
+        </Var>
+        <Print format="%d\n">
+            <Sub>
+                <Add>
+                    <Load name="x"/>
+                    <Load name="y"/>
+                </Add>
+                <Load name="z"/>
+            </Sub>
+        </Print>
+    </Func>
+</Root>

--- a/main.cpp
+++ b/main.cpp
@@ -306,8 +306,15 @@ auto compile_module(std::unique_ptr<llvm::Module> module,
     dest.flush();
 }
 
-int main() {
-    auto tree = parse_program("../examples/var.xml");
+int main(int argc, char** argv) {
+    // TODO: Use some argument parser
+    if (argc != 2) {
+        return 1;
+    }
+
+    auto source_filename = std::string(argv[1]);
+
+    auto tree = parse_program(source_filename);
     auto module = compile_program(tree);
 
     std::string object_file =

--- a/main.cpp
+++ b/main.cpp
@@ -209,6 +209,27 @@ auto compile_program(boost::property_tree::ptree const& tree) {
                 auto var = named_values[name];
 
                 ret.push_back(builder.CreateLoad(var));
+            } else if (node.first == "Add") {
+                auto values = recurse_tree(node.second);
+                assert(values.size() >= 2);
+
+                llvm::Value* sum = builder.CreateAdd(values[0], values[1]);
+                for (auto i = 2; i < values.size(); ++i) {
+                    sum = builder.CreateAdd(sum, values[i]);
+                }
+
+                ret.push_back(sum);
+            } else if (node.first == "Sub") {
+                auto values = recurse_tree(node.second);
+                assert(values.size() >= 2);
+
+                llvm::Value* difference =
+                    builder.CreateSub(values[0], values[1]);
+                for (auto i = 2; i < values.size(); ++i) {
+                    difference = builder.CreateSub(difference, values[i]);
+                }
+
+                ret.push_back(difference);
             }
         }
 


### PR DESCRIPTION
This PR implements the basic interface for defining local variables, namely
`Var`, `Store`, and `Load`, and a few numeric operations - `Add` and `Sub`. A
new example is added, which defines a few variables, adds them and subtracts
them in a specific way to end up with a very special result (lmao).
