### PR TITLE
feat: implement argument parsing via boost program_options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(tobsterlang)
 
-find_package(Boost)
+find_package(Boost COMPONENTS program_options)
 find_package(LLVM REQUIRED CONFIG)
 
 include_directories(${LLVM_INCLUDE_DIRS})
@@ -13,4 +13,4 @@ set(CMAKE_CXX_STANDARD 17)
 
 add_executable(tobsterlang main.cpp)
 
-target_link_libraries(tobsterlang "LLVM-${LLVM_PACKAGE_VERSION}")
+target_link_libraries(tobsterlang ${Boost_LIBRARIES} "LLVM-${LLVM_PACKAGE_VERSION}")

--- a/main.cpp
+++ b/main.cpp
@@ -347,6 +347,10 @@ auto get_optimization_level(std::string const& level) {
         return llvm::PassBuilder::OptimizationLevel::O2;
     } else if (level == "3") {
         return llvm::PassBuilder::OptimizationLevel::O3;
+    } else if (level == "s") {
+        return llvm::PassBuilder::OptimizationLevel::Os;
+    } else if (level == "z") {
+        return llvm::PassBuilder::OptimizationLevel::Oz;
     }
 
     return llvm::PassBuilder::OptimizationLevel::O0;

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,6 @@
+#ifndef NDEBUG
+#include <llvm/IR/IRPrintingPasses.h>
+#endif
 #include <llvm/Analysis/CGSCCPassManager.h>
 #include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/IR/IRBuilder.h>
@@ -314,6 +317,10 @@ auto compile_module(std::unique_ptr<llvm::Module> module,
     }
 
     llvm::legacy::PassManager pass;
+#ifndef NDEBUG
+    pass.add(llvm::createPrintModulePass(llvm::outs()));
+#endif
+
     auto filetype = llvm::CGFT_ObjectFile;
 
     if (target_machine->addPassesToEmitFile(pass, dest, nullptr, filetype)) {

--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,7 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <iostream>
 
+namespace pt = boost::property_tree;
 namespace po = boost::program_options;
 
 static llvm::LLVMContext llvm_context;
@@ -75,8 +76,8 @@ auto unescape(std::string const& str) {
 }
 
 auto parse_program(std::string const& filename) {
-    boost::property_tree::ptree tree;
-    boost::property_tree::read_xml(filename, tree);
+    pt::ptree tree;
+    pt::read_xml(filename, tree);
 
     return tree;
 }
@@ -100,15 +101,14 @@ auto get_type_by_name(std::string const& name) -> llvm::Type* {
     assert(0 && "unknown type");
 }
 
-auto compile_program(boost::property_tree::ptree const& tree) {
+auto compile_program(pt::ptree const& tree) {
     auto root_node = tree.get_child("Root");
     auto module_name = root_node.get_child("<xmlattr>.module").data();
 
     auto module = std::make_unique<llvm::Module>(module_name, llvm_context);
 
-    std::function<std::vector<llvm::Value*>(boost::property_tree::ptree const&)>
-        recurse_tree = [&](boost::property_tree::ptree const& tree)
-        -> std::vector<llvm::Value*> {
+    std::function<std::vector<llvm::Value*>(pt::ptree const&)> recurse_tree =
+        [&](pt::ptree const& tree) -> std::vector<llvm::Value*> {
         if (tree.empty()) {
             return {};
         }


### PR DESCRIPTION
This PR makes use of the program_options library from Boost to implement parsing
of the basic command line arguments the Tobsterlang compiler should accept,
namely input file, output file, and optimization level.
