### PR TITLE
feat: implement function calling, argument passing, and value returning

### DIFF
--- a/examples/hello.xml
+++ b/examples/hello.xml
@@ -1,7 +1,8 @@
 <Root module="tobster">
     <Func name="ZdraveitePriqteliAzSumTobstera">
-        <Print format="%s\n">
+        <Call name="printf">
+            <Value type="String" raw="true">%s\n</Value>
             <Value type="String">Hello, world!</Value>
-        </Print>
+        </Call>
     </Func>
 </Root>

--- a/examples/sum.xml
+++ b/examples/sum.xml
@@ -1,0 +1,20 @@
+<Root module="sum">
+    <Func name="add" x="Int32" y="Int32" returns="Int32">
+        <Return>
+            <Add>
+                <Load name="x"/>
+                <Load name="y"/>
+            </Add>
+        </Return>
+    </Func>
+
+    <Func name="ZdraveitePriqteliAzSumTobstera">
+        <Call name="printf">
+            <Value type="String" raw="true">%d\n</Value>
+            <Call name="add">
+                <Value type="Int32">400</Value>
+                <Value type="Int32">20</Value>
+            </Call>
+        </Call>
+    </Func>
+</Root>

--- a/examples/var.xml
+++ b/examples/var.xml
@@ -15,7 +15,8 @@
             <Value type="Int32">1</Value>
         </Store>
 
-        <Print format="%d\n">
+        <Call name="printf">
+            <Value type="String" raw="true">%d\n</Value>
             <Sub>
                 <Add>
                     <Load name="x"/>
@@ -23,6 +24,6 @@
                 </Add>
                 <Load name="z"/>
             </Sub>
-        </Print>
+        </Call>
     </Func>
 </Root>

--- a/main.cpp
+++ b/main.cpp
@@ -177,6 +177,11 @@ auto compile_program(pt::ptree const& tree) {
 
                 recurse_tree(subtree);
 
+                auto has_return = subtree.rbegin()->first == "Return";
+                if (!has_return) {
+                    builder.CreateRet(nullptr);
+                }
+
                 ret.push_back(func);
             } else if (node_name == "Print") {
                 auto format = subtree.get_child("<xmlattr>.format").data();

--- a/main.cpp
+++ b/main.cpp
@@ -177,8 +177,6 @@ auto compile_program(pt::ptree const& tree) {
 
                 recurse_tree(subtree);
 
-                builder.CreateRet(nullptr);
-
                 ret.push_back(func);
             } else if (node_name == "Print") {
                 auto format = subtree.get_child("<xmlattr>.format").data();
@@ -264,6 +262,11 @@ auto compile_program(pt::ptree const& tree) {
                 }
 
                 ret.push_back(difference);
+            } else if (node_name == "Return") {
+                auto values = recurse_tree(subtree);
+                assert(values.size() == 1);
+
+                builder.CreateRet(values[0]);
             }
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -168,6 +168,7 @@ auto compile_program(pt::ptree const& tree) {
 
                 builder.SetInsertPoint(func_body);
 
+                named_values.clear();
                 for (auto& arg : func->args()) {
                     auto arg_mem = builder.CreateAlloca(arg.getType());
                     builder.CreateStore(&arg, arg_mem);

--- a/main.cpp
+++ b/main.cpp
@@ -232,6 +232,13 @@ auto compile_program(pt::ptree const& tree) {
                 auto type_name = subtree.get_child("<xmlattr>.type").data();
                 auto value = subtree.data();
 
+                auto is_raw =
+                    subtree.get_child_optional("<xmlattr>.raw").has_value();
+
+                if (is_raw) {
+                    value = unescape(value);
+                }
+
                 auto type = get_type_by_name(type_name);
                 if (type->isIntegerTy()) {
                     ret.push_back(llvm::ConstantInt::get(

--- a/main.cpp
+++ b/main.cpp
@@ -161,6 +161,13 @@ auto compile_program(pt::ptree const& tree) {
 
                 builder.SetInsertPoint(func_body);
 
+                for (auto& arg : func->args()) {
+                    auto arg_mem = builder.CreateAlloca(arg.getType());
+                    builder.CreateStore(&arg, arg_mem);
+
+                    named_values[arg.getName().str()] = arg_mem;
+                }
+
                 recurse_tree(subtree);
 
                 builder.CreateRet(nullptr);

--- a/main.cpp
+++ b/main.cpp
@@ -267,6 +267,13 @@ auto compile_program(pt::ptree const& tree) {
                 assert(values.size() == 1);
 
                 builder.CreateRet(values[0]);
+            } else if (node_name == "Call") {
+                auto name = subtree.get_child("<xmlattr>.name").data();
+                auto func = module->getFunction(name);
+
+                auto args = recurse_tree(subtree);
+
+                ret.push_back(builder.CreateCall(func, args));
             }
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -264,9 +264,11 @@ auto compile_program(pt::ptree const& tree) {
                 ret.push_back(difference);
             } else if (node_name == "Return") {
                 auto values = recurse_tree(subtree);
-                assert(values.size() == 1);
-
-                builder.CreateRet(values[0]);
+                if (values.size() == 1) {
+                    builder.CreateRet(values[0]);
+                } else {
+                    builder.CreateRet(nullptr);
+                }
             } else if (node_name == "Call") {
                 auto name = subtree.get_child("<xmlattr>.name").data();
                 auto func = module->getFunction(name);

--- a/main.cpp
+++ b/main.cpp
@@ -121,6 +121,7 @@ auto compile_program(pt::ptree const& tree) {
         for (auto& [node_name, subtree] : tree) {
             if (node_name == "Func") {
                 std::string func_name;
+                llvm::Type* return_type = llvm::Type::getVoidTy(llvm_context);
 
                 std::vector<std::string> argument_names;
                 std::vector<llvm::Type*> argument_types;
@@ -135,6 +136,12 @@ auto compile_program(pt::ptree const& tree) {
                         continue;
                     }
 
+                    if (argument_name == "returns") {
+                        return_type = get_type_by_name(argument_value);
+
+                        continue;
+                    }
+
                     auto argument_type = get_type_by_name(argument_value);
 
                     argument_names.push_back(argument_name);
@@ -145,8 +152,8 @@ auto compile_program(pt::ptree const& tree) {
                     func_name = "main";
                 }
 
-                auto func_type = llvm::FunctionType::get(
-                    llvm::Type::getVoidTy(llvm_context), argument_types, false);
+                auto func_type =
+                    llvm::FunctionType::get(return_type, argument_types, false);
 
                 auto func = llvm::Function::Create(
                     func_type, llvm::Function::ExternalLinkage, func_name,


### PR DESCRIPTION
This PR implements calling functions by name, passing arguments to functions,
and returning values from functions. Arguments are stored on the stack, since
they need to act exactly like local variables. A relevant example is added
(examples/sum.xml), which demonstrates these features. TL;DR it defines a
function `sum`, which accepts two Int32 values and returns their sum. An
implicit return mechanism was implemented to keep the existing behavior, which
was automatically returning at the end of a function.
